### PR TITLE
error when $zci_options is an empty string

### DIFF
--- a/categories-images.php
+++ b/categories-images.php
@@ -24,6 +24,10 @@ function z_init() {
 	$z_taxonomies = get_taxonomies();
 	if (is_array($z_taxonomies)) {
 		$zci_options = get_option('zci_options');
+		
+		if (!is_array($zci_options))
+			$zci_options = array();
+		
 		if (empty($zci_options['excluded_taxonomies']))
 			$zci_options['excluded_taxonomies'] = array();
 		


### PR DESCRIPTION
setting $zci_options['excluded_taxonomies'] to a blank array when $zci_options is an empty strip causes PHP 7.2 fatal